### PR TITLE
feat: stream hashing via NAPI-RS 3 Web Stream API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "ryu",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -284,10 +285,13 @@ dependencies = [
  "bitflags",
  "ctor",
  "futures",
+ "futures-core",
  "napi-build",
  "napi-sys",
  "nohash-hasher",
  "rustc-hash",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -401,6 +405,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "pin-project-lite",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,9 +278,7 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d395473824516f38dd1071a1a37bc57daa7be65b293ebba4ead5f7abb017a2"
+version = "3.9.1"
 dependencies = [
  "bitflags",
  "ctor",
@@ -297,14 +295,10 @@ dependencies = [
 [[package]]
 name = "napi-build"
 version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
 
 [[package]]
 name = "napi-derive"
 version = "3.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b3f766e04667e6da0e181e2da4f85475d5a6513b7cf6a80bea184e224a5b42"
 dependencies = [
  "convert_case",
  "ctor",
@@ -317,8 +311,6 @@ dependencies = [
 [[package]]
 name = "napi-derive-backend"
 version = "5.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5af30503edf933ce7377cf6d4c877a62b0f1107ea05585f1b5e430e88d5baf"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -329,9 +321,7 @@ dependencies = [
 
 [[package]]
 name = "napi-sys"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
+version = "3.2.2"
 dependencies = [
  "libloading",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "blake2b_simd"
@@ -81,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -263,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mimalloc-safe"
@@ -278,7 +278,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.9.1"
+version = "3.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d3c7dd60231116a47854321c9ac8df6f13435d11aa3a59d8533a76e07a3730"
 dependencies = [
  "bitflags",
  "ctor",
@@ -295,10 +297,14 @@ dependencies = [
 [[package]]
 name = "napi-build"
 version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
 
 [[package]]
 name = "napi-derive"
 version = "3.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b3f766e04667e6da0e181e2da4f85475d5a6513b7cf6a80bea184e224a5b42"
 dependencies = [
  "convert_case",
  "ctor",
@@ -311,6 +317,8 @@ dependencies = [
 [[package]]
 name = "napi-derive-backend"
 version = "5.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d5af30503edf933ce7377cf6d4c877a62b0f1107ea05585f1b5e430e88d5baf"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -322,6 +330,8 @@ dependencies = [
 [[package]]
 name = "napi-sys"
 version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f5bcdf71abd3a50d00b49c1c2c75251cb3c913777d6139cd37dabc093a5e400"
 dependencies = [
  "libloading",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ blake2b_simd = "1.0"
 blake2s_simd = "1.0"
 blake3 = "1"
 hex = "0.4"
-napi = { version = "3", features = ["web_stream", "napi5"] }
+napi = { version = "3.9.2", features = ["web_stream", "napi5"] }
 napi-derive = "3"
 ryu = "1"
 tokio-stream = "0.1"
@@ -29,8 +29,3 @@ napi-build = "2"
 [profile.release]
 codegen-units = 1
 lto = true
-
-[patch.crates-io]
-napi = { path = "../napi-rs/crates/napi" }
-napi-derive = { path = "../napi-rs/crates/macro" }
-napi-build = { path = "../napi-rs/crates/build" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,10 @@ blake2b_simd = "1.0"
 blake2s_simd = "1.0"
 blake3 = "1"
 hex = "0.4"
-napi = "3"
+napi = { version = "3", features = ["web_stream", "napi5"] }
 napi-derive = "3"
 ryu = "1"
+tokio-stream = "0.1"
 
 [target.'cfg(all(not(target_os = "linux"), not(target_family = "wasm")))'.dependencies]
 mimalloc-safe = { version = "0.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,8 @@ napi-build = "2"
 [profile.release]
 codegen-units = 1
 lto = true
+
+[patch.crates-io]
+napi = { path = "../napi-rs/crates/napi" }
+napi-derive = { path = "../napi-rs/crates/macro" }
+napi-build = { path = "../napi-rs/crates/build" }

--- a/__test__/blake2.spec.ts
+++ b/__test__/blake2.spec.ts
@@ -92,11 +92,10 @@ test('blake2b digestStream errored stream rejects without crashing', async (t) =
   await t.throwsAsync(() => new Blake2BHasher().digestStream(errored))
 })
 
-test('blake2b digestStream invalid format rejects', (t) => {
-  // Format is now validated synchronously up front (before consuming the
-  // stream), so a bad format throws synchronously rather than returning a
-  // rejected Promise.
-  t.throws(() =>
+test('blake2b digestStream invalid format rejects', async (t) => {
+  // A bad format rejects the returned Promise (validated inside the async block,
+  // before any chunk is pulled) rather than throwing synchronously.
+  await t.throwsAsync(() =>
     new Blake2BHasher().digestStream(streamOf([Buffer.from('x')]), 'bogus'),
   )
 })

--- a/__test__/blake2.spec.ts
+++ b/__test__/blake2.spec.ts
@@ -10,6 +10,15 @@ import {
   blake2b,
 } from '../index'
 
+function streamOf(chunks: Buffer[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(c) {
+      for (const ch of chunks) c.enqueue(new Uint8Array(ch))
+      c.close()
+    },
+  })
+}
+
 test('blake2b', (t) => {
   const hasher = new Blake2BHasher()
   t.is(
@@ -55,4 +64,39 @@ test('blake2b digestStreamBuffer', async (t) => {
   const buf = Buffer.from('hello world stream test')
   const web = () => Readable.toWeb(Readable.from(buf))
   t.deepEqual(await new Blake2BHasher().digestStreamBuffer(web()), blake2b(buf))
+})
+
+test('blake2b digestStream multi-chunk correctness', async (t) => {
+  const chunks: Buffer[] = []
+  for (let i = 0; i < 64; i++) {
+    chunks.push(Buffer.from([i & 0xff, (i * 7) & 0xff, (i * 13) & 0xff]))
+  }
+  const concat = Buffer.concat(chunks)
+  const expected = blake2b(concat).toString('hex')
+  for (let attempt = 0; attempt < 5; attempt++) {
+    t.is(await new Blake2BHasher().digestStream(streamOf(chunks)), expected)
+  }
+  t.deepEqual(
+    await new Blake2BHasher().digestStreamBuffer(streamOf(chunks)),
+    blake2b(concat),
+  )
+})
+
+test('blake2b digestStream errored stream rejects without crashing', async (t) => {
+  const errored = new ReadableStream({
+    start(c) {
+      c.enqueue(new Uint8Array([1, 2, 3]))
+      c.error(new Error('boom'))
+    },
+  })
+  await t.throwsAsync(() => new Blake2BHasher().digestStream(errored))
+})
+
+test('blake2b digestStream invalid format rejects', (t) => {
+  // Format is now validated synchronously up front (before consuming the
+  // stream), so a bad format throws synchronously rather than returning a
+  // rejected Promise.
+  t.throws(() =>
+    new Blake2BHasher().digestStream(streamOf([Buffer.from('x')]), 'bogus'),
+  )
 })

--- a/__test__/blake2.spec.ts
+++ b/__test__/blake2.spec.ts
@@ -1,3 +1,5 @@
+import { Readable } from 'node:stream'
+
 import test from 'ava'
 
 import {
@@ -5,6 +7,7 @@ import {
   Blake2BpHasher,
   Blake2SpHasher,
   Blake2SHasher,
+  blake2b,
 } from '../index'
 
 test('blake2b', (t) => {
@@ -37,4 +40,19 @@ test('blake2sp', (t) => {
     hasher.update('hello').digest('hex'),
     '223dfe42565ddf97210b34a384860b603717d5c63c1872c9fc99f1b15de6631b',
   )
+})
+
+test('blake2b digestStream', async (t) => {
+  const buf = Buffer.from('hello world stream test')
+  const web = () => Readable.toWeb(Readable.from(buf))
+  t.is(
+    await new Blake2BHasher().digestStream(web()),
+    blake2b(buf).toString('hex'),
+  )
+})
+
+test('blake2b digestStreamBuffer', async (t) => {
+  const buf = Buffer.from('hello world stream test')
+  const web = () => Readable.toWeb(Readable.from(buf))
+  t.deepEqual(await new Blake2BHasher().digestStreamBuffer(web()), blake2b(buf))
 })

--- a/__test__/blake3.spec.ts
+++ b/__test__/blake3.spec.ts
@@ -4,6 +4,15 @@ import test from 'ava'
 
 import { Blake3Hasher, blake3 } from '../index'
 
+function streamOf(chunks: Buffer[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(c) {
+      for (const ch of chunks) c.enqueue(new Uint8Array(ch))
+      c.close()
+    },
+  })
+}
+
 test('blake3', (t) => {
   const hasher = new Blake3Hasher()
   t.is(
@@ -62,5 +71,50 @@ test('blake3 digestStream format base64', async (t) => {
   t.is(
     await new Blake3Hasher().digestStream(web(), 'base64'),
     new Blake3Hasher().update(buf).digest('base64'),
+  )
+})
+
+test('blake3 digestStream multi-chunk correctness', async (t) => {
+  const chunks: Buffer[] = []
+  for (let i = 0; i < 64; i++) {
+    chunks.push(Buffer.from([i & 0xff, (i * 7) & 0xff, (i * 13) & 0xff]))
+  }
+  const expected = blake3(Buffer.concat(chunks)).toString('hex')
+  // The lost-chunk bug was deterministic at 64 chunks; loop to be safe.
+  for (let attempt = 0; attempt < 5; attempt++) {
+    t.is(await new Blake3Hasher().digestStream(streamOf(chunks)), expected)
+  }
+})
+
+test('blake3 digestStreamBuffer multi-chunk correctness', async (t) => {
+  const chunks: Buffer[] = []
+  for (let i = 0; i < 64; i++) {
+    chunks.push(Buffer.from([i & 0xff, (i * 7) & 0xff, (i * 13) & 0xff]))
+  }
+  const expected = blake3(Buffer.concat(chunks))
+  for (let attempt = 0; attempt < 5; attempt++) {
+    t.deepEqual(
+      await new Blake3Hasher().digestStreamBuffer(streamOf(chunks)),
+      expected,
+    )
+  }
+})
+
+test('blake3 digestStream errored stream rejects without crashing', async (t) => {
+  const errored = new ReadableStream({
+    start(c) {
+      c.enqueue(new Uint8Array([1, 2, 3]))
+      c.error(new Error('boom'))
+    },
+  })
+  await t.throwsAsync(() => new Blake3Hasher().digestStream(errored))
+})
+
+test('blake3 digestStream invalid format rejects', (t) => {
+  // Format is now validated synchronously up front (before consuming the
+  // stream), so a bad format throws synchronously rather than returning a
+  // rejected Promise.
+  t.throws(() =>
+    new Blake3Hasher().digestStream(streamOf([Buffer.from('x')]), 'bogus'),
   )
 })

--- a/__test__/blake3.spec.ts
+++ b/__test__/blake3.spec.ts
@@ -1,6 +1,8 @@
+import { Readable } from 'node:stream'
+
 import test from 'ava'
 
-import { Blake3Hasher } from '../index'
+import { Blake3Hasher, blake3 } from '../index'
 
 test('blake3', (t) => {
   const hasher = new Blake3Hasher()
@@ -16,5 +18,49 @@ test('blake3 keyed', (t) => {
   t.is(
     hasher.update('hello world').digest('hex'),
     'e654a33cb9b9573b8cf9f4a3c5c8bc19dbfeb6362584ee55b1545e98492650f0',
+  )
+})
+
+test('blake3 digestStream', async (t) => {
+  const buf = Buffer.from('hello world stream test')
+  const web = () => Readable.toWeb(Readable.from(buf))
+  t.is(
+    await new Blake3Hasher().digestStream(web()),
+    blake3(buf).toString('hex'),
+  )
+})
+
+test('blake3 digestStreamBuffer', async (t) => {
+  const buf = Buffer.from('hello world stream test')
+  const web = () => Readable.toWeb(Readable.from(buf))
+  t.deepEqual(await new Blake3Hasher().digestStreamBuffer(web()), blake3(buf))
+})
+
+test('blake3 digestStream composition and non-mutation', async (t) => {
+  const buf = Buffer.from('hello world stream test')
+  const web = () => Readable.toWeb(Readable.from(buf))
+
+  const h = new Blake3Hasher()
+  h.update('prefix')
+  const streamed = await h.digestStream(web())
+
+  const expected = new Blake3Hasher().update('prefix').update(buf).digest('hex')
+  t.is(streamed, expected)
+
+  // digestStream took &self (snapshot via clone), so `h` is NOT consumed.
+  // It still only holds 'prefix' and can be reused.
+  const streamedAgain = await h.digestStream(web())
+  t.is(streamedAgain, expected)
+
+  // And digest('hex') reflects only 'prefix' (stream input was not merged in).
+  t.is(h.digest('hex'), new Blake3Hasher().update('prefix').digest('hex'))
+})
+
+test('blake3 digestStream format base64', async (t) => {
+  const buf = Buffer.from('hello world stream test')
+  const web = () => Readable.toWeb(Readable.from(buf))
+  t.is(
+    await new Blake3Hasher().digestStream(web(), 'base64'),
+    new Blake3Hasher().update(buf).digest('base64'),
   )
 })

--- a/__test__/blake3.spec.ts
+++ b/__test__/blake3.spec.ts
@@ -110,11 +110,10 @@ test('blake3 digestStream errored stream rejects without crashing', async (t) =>
   await t.throwsAsync(() => new Blake3Hasher().digestStream(errored))
 })
 
-test('blake3 digestStream invalid format rejects', (t) => {
-  // Format is now validated synchronously up front (before consuming the
-  // stream), so a bad format throws synchronously rather than returning a
-  // rejected Promise.
-  t.throws(() =>
+test('blake3 digestStream invalid format rejects', async (t) => {
+  // A bad format rejects the returned Promise (validated inside the async block,
+  // before any chunk is pulled) rather than throwing synchronously.
+  await t.throwsAsync(() =>
     new Blake3Hasher().digestStream(streamOf([Buffer.from('x')]), 'bogus'),
   )
 })

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,8 @@ export declare class Blake2BHasher {
   update(input: string | Buffer | number): this
   digest(format?: string | undefined | null): string
   digestBuffer(): Buffer
+  digestStream(stream: ReadableStream<Uint8Array>, format?: string | undefined | null): Promise<string>
+  digestStreamBuffer(stream: ReadableStream<Uint8Array>): Promise<Buffer>
 }
 export type Blake2bHasher = Blake2BHasher
 
@@ -48,6 +50,8 @@ export declare class Blake2BpHasher {
   update(input: string | Buffer | number): this
   digest(format?: string | undefined | null): string
   digestBuffer(): Buffer
+  digestStream(stream: ReadableStream<Uint8Array>, format?: string | undefined | null): Promise<string>
+  digestStreamBuffer(stream: ReadableStream<Uint8Array>): Promise<Buffer>
 }
 export type Blake2bpHasher = Blake2BpHasher
 
@@ -64,6 +68,8 @@ export declare class Blake2SHasher {
   update(input: string | Buffer | number): this
   digest(format?: string | undefined | null): string
   digestBuffer(): Buffer
+  digestStream(stream: ReadableStream<Uint8Array>, format?: string | undefined | null): Promise<string>
+  digestStreamBuffer(stream: ReadableStream<Uint8Array>): Promise<Buffer>
 }
 export type Blake2sHasher = Blake2SHasher
 
@@ -106,6 +112,8 @@ export declare class Blake2SpHasher {
   update(input: string | Buffer | number): this
   digest(format?: string | undefined | null): string
   digestBuffer(): Buffer
+  digestStream(stream: ReadableStream<Uint8Array>, format?: string | undefined | null): Promise<string>
+  digestStreamBuffer(stream: ReadableStream<Uint8Array>): Promise<Buffer>
 }
 export type Blake2spHasher = Blake2SpHasher
 
@@ -125,6 +133,8 @@ export declare class Blake3Hasher {
   update(input: string | Uint8Array | number): this
   digest(format?: string | undefined | null): string
   digestBuffer(): Buffer
+  digestStream(stream: ReadableStream<Uint8Array>, format?: string | undefined | null): Promise<string>
+  digestStreamBuffer(stream: ReadableStream<Uint8Array>): Promise<Buffer>
 }
 
 export declare function blake2b(input: string | Uint8Array): Buffer

--- a/index.js
+++ b/index.js
@@ -525,24 +525,38 @@ function requireNative() {
 
 nativeBinding = requireNative()
 
-if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
+// NAPI_RS_FORCE_WASI is a tri-state flag:
+//   unset / any other value → native binding preferred, WASI is only a fallback
+//   'true'                   → force WASI fallback even if native loaded
+//   'error'                  → force WASI and throw if no WASI binding is found
+// Treating any non-empty string as truthy (the historical behavior) meant
+// NAPI_RS_FORCE_WASI=false, NAPI_RS_FORCE_WASI=0, etc. inadvertently triggered
+// the WASI path, causing ENOENT for packages shipped without a .wasi.cjs file.
+const forceWasi =
+  process.env.NAPI_RS_FORCE_WASI === 'true' || process.env.NAPI_RS_FORCE_WASI === 'error'
+
+if (!nativeBinding || forceWasi) {
   let wasiBinding = null
   let wasiBindingError = null
   try {
     wasiBinding = require('./blake.wasi.cjs')
     nativeBinding = wasiBinding
   } catch (err) {
-    if (process.env.NAPI_RS_FORCE_WASI) {
+    if (forceWasi) {
       wasiBindingError = err
     }
   }
-  if (!nativeBinding) {
+  if (!nativeBinding || forceWasi) {
     try {
       wasiBinding = require('@napi-rs/blake-hash-wasm32-wasi')
       nativeBinding = wasiBinding
     } catch (err) {
-      if (process.env.NAPI_RS_FORCE_WASI) {
-        wasiBindingError.cause = err
+      if (forceWasi) {
+        if (!wasiBindingError) {
+          wasiBindingError = err
+        } else {
+          wasiBindingError.cause = err
+        }
         loadErrors.push(err)
       }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,18 +14,32 @@ mod blake2_params;
 
 use blake2_params::{Blake2bParam, Blake2bpParam, Blake2sParam, Blake2spParam};
 
-fn encode_digest(bytes: &[u8], format: Option<String>) -> Result<String> {
-  match format.as_deref().unwrap_or("hex") {
-    "hex" => Ok(hex::encode(bytes)),
-    "base64" => Ok(base64::engine::general_purpose::STANDARD.encode(bytes)),
-    "base64-url-safe" => Ok(
-      base64::engine::general_purpose::GeneralPurpose::new(
+enum DigestFormat {
+  Hex,
+  Base64,
+  Base64UrlSafe,
+}
+
+impl DigestFormat {
+  fn parse(format: Option<String>) -> Result<Self> {
+    match format.as_deref().unwrap_or("hex") {
+      "hex" => Ok(Self::Hex),
+      "base64" => Ok(Self::Base64),
+      "base64-url-safe" => Ok(Self::Base64UrlSafe),
+      _ => Err(Error::new(Status::InvalidArg, "Invalid format".to_owned())),
+    }
+  }
+
+  fn encode(&self, bytes: &[u8]) -> String {
+    match self {
+      Self::Hex => hex::encode(bytes),
+      Self::Base64 => base64::engine::general_purpose::STANDARD.encode(bytes),
+      Self::Base64UrlSafe => base64::engine::general_purpose::GeneralPurpose::new(
         &base64::alphabet::URL_SAFE,
         base64::engine::general_purpose::PAD,
       )
       .encode(bytes),
-    ),
-    _ => Err(Error::new(Status::InvalidArg, "Invalid format".to_owned())),
+    }
   }
 }
 
@@ -90,13 +104,14 @@ macro_rules! impl_hasher {
         stream: ReadableStream<Uint8Array>,
         format: Option<String>,
       ) -> Result<AsyncBlock<String>> {
+        let format = DigestFormat::parse(format)?;
         let mut state = self.0.clone();
         let mut reader = stream.read()?;
         AsyncBlockBuilder::new(async move {
           while let Some(chunk) = reader.next().await {
             state.update(chunk?.as_ref());
           }
-          encode_digest(state.finalize().as_ref(), format)
+          Ok(format.encode(state.finalize().as_ref()))
         })
         .build(env)
       }
@@ -235,13 +250,14 @@ impl Blake3Hasher {
     stream: ReadableStream<Uint8Array>,
     format: Option<String>,
   ) -> Result<AsyncBlock<String>> {
+    let format = DigestFormat::parse(format)?;
     let mut state = self.0.clone();
     let mut reader = stream.read()?;
     AsyncBlockBuilder::new(async move {
       while let Some(chunk) = reader.next().await {
         state.update(chunk?.as_ref());
       }
-      encode_digest(state.finalize().as_bytes(), format)
+      Ok(format.encode(state.finalize().as_bytes()))
     })
     .build(env)
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,10 +104,12 @@ macro_rules! impl_hasher {
         stream: ReadableStream<Uint8Array>,
         format: Option<String>,
       ) -> Result<AsyncBlock<String>> {
-        let format = DigestFormat::parse(format)?;
         let mut state = self.0.clone();
         let mut reader = stream.read()?;
         AsyncBlockBuilder::new(async move {
+          // Validate the format before pulling any chunks so a bad format rejects the
+          // returned Promise (rather than throwing synchronously) without draining input.
+          let format = DigestFormat::parse(format)?;
           while let Some(chunk) = reader.next().await {
             state.update(chunk?.as_ref());
           }
@@ -250,10 +252,12 @@ impl Blake3Hasher {
     stream: ReadableStream<Uint8Array>,
     format: Option<String>,
   ) -> Result<AsyncBlock<String>> {
-    let format = DigestFormat::parse(format)?;
     let mut state = self.0.clone();
     let mut reader = stream.read()?;
     AsyncBlockBuilder::new(async move {
+      // Validate the format before pulling any chunks so a bad format rejects the
+      // returned Promise (rather than throwing synchronously) without draining input.
+      let format = DigestFormat::parse(format)?;
       while let Some(chunk) = reader.next().await {
         state.update(chunk?.as_ref());
       }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 use base64::Engine;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
+use tokio_stream::StreamExt;
 
 #[cfg(not(target_family = "wasm"))]
 #[global_allocator]
@@ -12,6 +13,21 @@ static ALLOC: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 mod blake2_params;
 
 use blake2_params::{Blake2bParam, Blake2bpParam, Blake2sParam, Blake2spParam};
+
+fn encode_digest(bytes: &[u8], format: Option<String>) -> Result<String> {
+  match format.as_deref().unwrap_or("hex") {
+    "hex" => Ok(hex::encode(bytes)),
+    "base64" => Ok(base64::engine::general_purpose::STANDARD.encode(bytes)),
+    "base64-url-safe" => Ok(
+      base64::engine::general_purpose::GeneralPurpose::new(
+        &base64::alphabet::URL_SAFE,
+        base64::engine::general_purpose::PAD,
+      )
+      .encode(bytes),
+    ),
+    _ => Err(Error::new(Status::InvalidArg, "Invalid format".to_owned())),
+  }
+}
 
 macro_rules! impl_hasher {
   ($name:ident, $algorithm:expr, $params:ident) => {
@@ -65,6 +81,41 @@ macro_rules! impl_hasher {
       #[napi]
       pub fn digest_buffer(&mut self) -> Buffer {
         self.0.finalize().as_ref().into()
+      }
+
+      #[napi]
+      pub fn digest_stream(
+        &self,
+        env: &Env,
+        stream: ReadableStream<Uint8Array>,
+        format: Option<String>,
+      ) -> Result<AsyncBlock<String>> {
+        let mut state = self.0.clone();
+        let mut reader = stream.read()?;
+        AsyncBlockBuilder::new(async move {
+          while let Some(chunk) = reader.next().await {
+            state.update(chunk?.as_ref());
+          }
+          encode_digest(state.finalize().as_ref(), format)
+        })
+        .build(env)
+      }
+
+      #[napi]
+      pub fn digest_stream_buffer(
+        &self,
+        env: &Env,
+        stream: ReadableStream<Uint8Array>,
+      ) -> Result<AsyncBlock<Buffer>> {
+        let mut state = self.0.clone();
+        let mut reader = stream.read()?;
+        AsyncBlockBuilder::new(async move {
+          while let Some(chunk) = reader.next().await {
+            state.update(chunk?.as_ref());
+          }
+          Ok(Buffer::from(state.finalize().as_ref()))
+        })
+        .build(env)
       }
     }
   };
@@ -175,6 +226,41 @@ impl Blake3Hasher {
   #[napi]
   pub fn digest_buffer(&mut self) -> Buffer {
     self.0.finalize().as_bytes().to_vec().into()
+  }
+
+  #[napi]
+  pub fn digest_stream(
+    &self,
+    env: &Env,
+    stream: ReadableStream<Uint8Array>,
+    format: Option<String>,
+  ) -> Result<AsyncBlock<String>> {
+    let mut state = self.0.clone();
+    let mut reader = stream.read()?;
+    AsyncBlockBuilder::new(async move {
+      while let Some(chunk) = reader.next().await {
+        state.update(chunk?.as_ref());
+      }
+      encode_digest(state.finalize().as_bytes(), format)
+    })
+    .build(env)
+  }
+
+  #[napi]
+  pub fn digest_stream_buffer(
+    &self,
+    env: &Env,
+    stream: ReadableStream<Uint8Array>,
+  ) -> Result<AsyncBlock<Buffer>> {
+    let mut state = self.0.clone();
+    let mut reader = stream.read()?;
+    AsyncBlockBuilder::new(async move {
+      while let Some(chunk) = reader.next().await {
+        state.update(chunk?.as_ref());
+      }
+      Ok(Buffer::from(state.finalize().as_bytes().as_slice()))
+    })
+    .build(env)
   }
 }
 


### PR DESCRIPTION
## What

Adds `digestStream(stream, format?)` → `Promise<string>` and `digestStreamBuffer(stream)` → `Promise<Buffer>` to **all five hashers** (Blake2b / Blake2bp / Blake2s / Blake2sp / Blake3). Callers can hash a web `ReadableStream<Uint8Array>` directly, with the hashing running **off the main JS thread** on the tokio runtime.

```js
import { createReadStream } from 'node:fs'
import { Readable } from 'node:stream'

const hex = await new Blake3Hasher().digestStream(
  Readable.toWeb(createReadStream('big.bin')),
)
```

- Close https://github.com/Brooooooklyn/blake-hash/issues/107

## How

- Consumes the JS stream via the NAPI-RS 3.9 Web Stream API: `stream.read()` → `Reader<Uint8Array>` (a `futures_core::Stream`), folded into the hasher inside an `AsyncBlockBuilder` future → resolves a `Promise`.
- **Non-mutating:** `digestStream` snapshots state via `.clone()`, so it composes with prior `update()` calls and keyed/derive-key constructors, and leaves the hasher reusable — matching the repeatable semantics of the existing `digest()`.
- Invalid `format` rejects the returned Promise (validated inside the async block before pulling chunks) rather than throwing synchronously.

## Dependency note

Depends on the published **`napi = "3.9.2"`** (pinned), which carries the `ReadableStream` `Reader` fix from napi-rs/napi-rs#3328 (lost chunks on multi-chunk streams + process abort on errored streams, plus off-thread-drop / pending-exception hardening). The earlier local `[patch.crates-io]` → `../napi-rs` is removed; a clean checkout builds against crates.io.

## Tests

`__test__/blake2.spec.ts` + `__test__/blake3.spec.ts` assert stream == one-shot equivalence, the buffer variant, multi-chunk correctness (×5 repeats), base64 format, composition + non-mutation, invalid-format rejection, and that an errored stream rejects without crashing the process. **19/19 pass; denolint clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)